### PR TITLE
Preload cache if not present

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ fast_json
 boto3
 bottle
 gunicorn
-via-api>=0.0.8
+via-api>=0.0.16
 osmnx

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ INSTALL_REQUIRES = (
     'boto3',
     'bottle',
     'gunicorn',
-    'via-api>=0.0.8',
+    'via-api>=0.0.16',
     'osmnx'
 )
 

--- a/src/via_web/bin/bottle_entry.py
+++ b/src/via_web/bin/bottle_entry.py
@@ -2,12 +2,12 @@ import argparse
 import threading
 
 import bottle
-from bottle import response
 
 from ..api import *
 
 from via import logger
 from via.pull_journeys import pull_journeys
+from via.utils import setup_cache
 
 from via.geojson.generate import generate_geojson
 
@@ -38,6 +38,7 @@ def main():
     )
     args = parser.parse_args()
 
+    setup_cache()
     update_journeys()
     generate_geojson(
         None,


### PR DESCRIPTION
Includes network / edge / other useful things so they don't need to be
regenerated or loaded from overpass which can take a long time

Currently the cache expands to be 2GB and is for all of ireland but if journeys span multiple networks new networks for that bbox / poly will need to be pulled
the current network cells which were generated in a sort of grid are 1000km^2