### PR TITLE
Bump via-api 0.0.54

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ fast_json
 boto3
 bottle
 gunicorn
-via-api==0.0.53
+via-api==0.0.54
 osmnx

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,13 @@ INSTALL_REQUIRES = (
     'boto3',
     'bottle',
     'gunicorn',
-    'via-api==0.0.53',
+    'via-api==0.0.54',
     'osmnx'
 )
 
 setup(
     name='via-web',
-    version='0.1.14',
+    version='0.1.15',
     python_requires='>=3.6',
     description='Analysing and serving crowdsourced road quality data',
     author='Conor Flynn',


### PR DESCRIPTION
Safer edge getting and ignore journeys with bad / too little data