### PR TITLE
Remove danger as a metric

### DIFF
--- a/vue/via-web/src/components/ViaMap.vue
+++ b/vue/via-web/src/components/ViaMap.vue
@@ -96,13 +96,6 @@ export default {
           percent = 100 * ((feature.properties.speed - minVal) / (maxVal - minVal))
         }
       }
-      if (this.$store.state.selectedMetric == 'danger') {
-        minVal = 0
-        maxVal = 2
-        percent = 100 * (1 - 
-          ((feature.properties.collisions.length - minVal) / (maxVal - minVal))
-        )
-      }
 
       return {
         color: this.getColour(percent),

--- a/vue/via-web/src/components/ViaSidebar.vue
+++ b/vue/via-web/src/components/ViaSidebar.vue
@@ -29,9 +29,8 @@
             href="https://github.com/RobertLucey/via-app/releases/latest">Via
             app</a> calculates the quality of roads you cycle on and allows
           them to be aggregated with all other journeys so you can get a full
-          view of what roads cyclists use, what condition the roads are in, how
-          efficient different routes are and what areas have had dangerous
-          collisions on them.
+          view of what roads cyclists use, what condition the roads are in and how
+          efficient different routes are.
         </p>
         <p>
           Feel free to start exploring by expanding the Explore tab below,

--- a/vue/via-web/src/components/ViaSidebarExamplesView.vue
+++ b/vue/via-web/src/components/ViaSidebarExamplesView.vue
@@ -15,10 +15,6 @@
       <li>
         <a href="http://127.0.0.1:8080/?showDetailsTable=true&selectedMetric=usage&earliestDate=2021-01&latestDate=2022-12&lat=53.33471863080541&lng=-6.2694597244262695&zoomLevel=15">Most Used Roads</a>
       </li>
-      <li>
-        <a
-          href="http://127.0.0.1:8080/?showDetailsTable=true&selectedMetric=danger&earliestDate=2021-01&latestDate=2022-12&lat=53.33303200603857&lng=-6.261059045791627&zoomLevel=17">Dangerous City Thoroughfare</a>
-      </li>
     </ul>
   </div>
 </template>

--- a/vue/via-web/src/components/ViaSidebarExploreView.vue
+++ b/vue/via-web/src/components/ViaSidebarExploreView.vue
@@ -42,7 +42,6 @@
         <option value="quality">Quality</option>
         <option value="usage">Usage</option>
         <option value="speed">Speed</option>
-        <option value="danger">Danger</option>
       </select>
 
       <label for="showDetailsTable">


### PR DESCRIPTION
Can't get recent or reliable data (2016 or later) so not much point in
trying to support it. Also removing should speed things up